### PR TITLE
修复非16进制下消息不显示的bug

### DIFF
--- a/serialportassistant.cpp
+++ b/serialportassistant.cpp
@@ -199,6 +199,10 @@ void SerialPortAssistant::receive(void)
             display += temp;
         }
     }
+    else
+    {
+        display = data;
+    }
 
     /* Add time to show. */
     if(ui->showTime->isChecked())


### PR DESCRIPTION
不勾选16进制显示，收到的串口消息不会正常显示，本提交修复了这个bug